### PR TITLE
Disable non-blocking IO for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,9 @@ before_install:
 - source /home/travis/google-cloud-sdk/path.bash.inc
 - tar -xzf credentials.tar.gz
 - gcloud auth activate-service-account --key-file client-secret.json
+before_script:
+  # Make sure stdout is in blocking mode. Otherwise builds will fail due to large writes to stdout
+  # See: https://github.com/travis-ci/travis-ci/issues/4704. If this gets fixed, this line can be removed.
+  - python3 -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
 script:
 - gsutil rsync -d -r files gs://io-osf-staging-static


### PR DESCRIPTION
Otherwise verbose tar extraction of Google Cloud SDK breaks Travis
See: https://github.com/travis-ci/travis-ci/issues/4704